### PR TITLE
Fix the bug of navigating in home page not tracking the active biome

### DIFF
--- a/scripts/home/home.js
+++ b/scripts/home/home.js
@@ -301,6 +301,7 @@ function initBiomeControls() {
     current.removeEventListener("click", targetEvent);
     current.addEventListener("click", redirectHandler);
     current.classList.add("active");
+    sessionStorage.setItem("activeBiome", current.id);
     hideContent(); // always hide the text content of the currently active biome
   }
 


### PR DESCRIPTION
I just noticed that I forgot to also add the tracking to navigation in home page.

Let's consider an example scenario:

1. I started at Forest in home page, moved to Marine, then went inside Marine.
2. Once I'm inside Marine, I navigated to Tundra, then go back to home.
3. When I'm at home page, the slider now will have Tundra in the center.

Above is the expected behavior of the tracking logic. However, when navigating in home page, regardless of means (click, keyboard, touchpad, swipe), it didn't keep track of the current one. Back to the example scenario, now I navigated from Tundra to Mesa in home page. On page reload, the slider turned back to previous state, which is Tundra being in the center (supposed to be Mesa instead).

Hence, the change was just to add the tracking logic to home page as well. 
